### PR TITLE
Fixed typographical error, changed appart to apart in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Here's an overview of the configuration options in the `settings.json` file:
     sitemenus:   List of menus that posts can appear in - ["bookmarks", "2011"]
     strings:     A hash of stranslation strings for each language
 
-Appart from the `settings.json` file, you can also configure your posts individually by using headers. A post filename should look like this:
+Apart from the `settings.json` file, you can also configure your posts individually by using headers. A post filename should look like this:
 
     This is my first post.en.md
 


### PR DESCRIPTION
@skid, I've corrected a typographical error in the documentation of the [this-blog](https://github.com/skid/this-blog) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
